### PR TITLE
Use rubocop 0.59.0

### DIFF
--- a/appbooster_rubocop_config.gemspec
+++ b/appbooster_rubocop_config.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bump", ">= 0.5.4"
 
-  spec.add_dependency "rubocop", "~> 0.51.0"
+  spec.add_dependency "rubocop", "~> 0.59.0"
   spec.add_dependency "rubocop-rspec", "~> 1.20"
 end

--- a/lib/rubocop/appbooster_rubocop_config/version.rb
+++ b/lib/rubocop/appbooster_rubocop_config/version.rb
@@ -1,3 +1,3 @@
 module AppboosterRubocopConfig
-  VERSION = "0.1.4".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Обновляем rubocop в зависимостях до последней (0.59.0) версии.

Текущая версия (0.51.0) не поддерживает ruby 2.5