### PR TITLE
update rubocop dependency to ~> 0.60

### DIFF
--- a/appbooster_rubocop_config.gemspec
+++ b/appbooster_rubocop_config.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bump", ">= 0.5.4"
 
-  spec.add_dependency "rubocop", "~> 0.59.0"
+  spec.add_dependency "rubocop", "~> 0.60"
   spec.add_dependency "rubocop-rspec", "~> 1.20"
 end


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Updates rubocop dependecy to '~> 0.60'