### PR TITLE
Feature/word symbol length

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -3,6 +3,7 @@ require:
 
 AllCops:
   Include:
+    - "**/*.rb"
     - "Rakefile"
     - "config.ru"
     - "lib/**/*.rake"
@@ -67,6 +68,12 @@ Style/ClassAndModuleChildren:
 
 Style/NumericPredicate:
   Enabled: false
+
+Style/SymbolArray:
+  MinSize: 4
+
+Style/WordArray:
+  MinSize: 4
 
 Lint/UnlessMultipleConditions:
   Description: 'Do not use `unless` with multiple conditions.'


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Предлагаю использовать правило для форматирования символьных и строковых массивов от четырех элементов и выше. На мой взгляд массив и двух-трех элементов смотрится нормально.

```ruby
# good
%i[foo bar baz]

# also good
[:foo, :bar, :baz]

# bad
[:foo, :bar, :baz, :taz]
```