### PR TITLE
update rubocop && update rubocop default config

### DIFF
--- a/appbooster_rubocop_config.gemspec
+++ b/appbooster_rubocop_config.gemspec
@@ -33,6 +33,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bump", ">= 0.5.4"
 
-  spec.add_dependency "rubocop", "~> 0.72"
-  spec.add_dependency "rubocop-rspec", "~> 1.33"
+  spec.add_dependency "rubocop", "~> 0.75"
+  spec.add_dependency "rubocop-rspec", "~> 1.36"
 end

--- a/default.yml
+++ b/default.yml
@@ -38,7 +38,7 @@ Naming/FileName:
     - "Capfile"
     - "Vagrantfile"
 
-VariableName:
+Naming/VariableName:
   EnforcedStyle: snake_case
 
 # Single quotes being faster is hardly measurable and only affects parse time.

--- a/lib/rubocop/appbooster_rubocop_config/version.rb
+++ b/lib/rubocop/appbooster_rubocop_config/version.rb
@@ -1,3 +1,3 @@
 module AppboosterRubocopConfig
-  VERSION = "0.4".freeze
+  VERSION = "0.5".freeze
 end

--- a/spec/rubocop/cop/lint/unless_multiple_conditions_spec.rb
+++ b/spec/rubocop/cop/lint/unless_multiple_conditions_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe RuboCop::Cop::Lint::UnlessMultipleConditions do
   let(:config) { RuboCop::Config.new }
 
   it "registers an offense when using `unless` with multiple `and` conditions" do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       unless foo && bar
              ^^^^^^^^^^ Avoid using `unless` with multiple conditions.
         something
@@ -15,7 +15,7 @@ RSpec.describe RuboCop::Cop::Lint::UnlessMultipleConditions do
   end
 
   it "registers an offense when using `unless` with multiple `or` conditions" do
-    expect_offense(<<-RUBY.strip_indent)
+    expect_offense(<<~RUBY)
       unless foo || bar
              ^^^^^^^^^^ Avoid using `unless` with multiple conditions.
         something
@@ -24,7 +24,7 @@ RSpec.describe RuboCop::Cop::Lint::UnlessMultipleConditions do
   end
 
   it "does not register an offense when using `if` with multiple `and` conditions" do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       if !foo && !bar
         something
       end
@@ -32,7 +32,7 @@ RSpec.describe RuboCop::Cop::Lint::UnlessMultipleConditions do
   end
 
   it "does not register an offense when using `if` with multiple `or` conditions" do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       if !foo || !bar
         something
       end
@@ -40,7 +40,7 @@ RSpec.describe RuboCop::Cop::Lint::UnlessMultipleConditions do
   end
 
   it "does not register an offense when using `unless` with single condition" do
-    expect_no_offenses(<<-RUBY.strip_indent)
+    expect_no_offenses(<<~RUBY)
       unless foo
         something
       end


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Обновил rubocop, обновил default конфигурацию, поправил тест.
Причина обновления, следующая ошибка:
`rubocop_config-67ab2ad0f2b5/default.yml: Warning: no department given for VariableName.`
