### PR TITLE
Fix cop name

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -24,7 +24,7 @@ Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # Commonly used screens these days easily fit more than 80 characters.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/AbcSize:

--- a/default.yml
+++ b/default.yml
@@ -20,7 +20,7 @@ AllCops:
 Layout/SpaceInLambdaLiteral:
   EnforcedStyle: require_space
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # Commonly used screens these days easily fit more than 80 characters.


### PR DESCRIPTION
#### :tophat: Что? Зачем?
```
Error: The `Layout/IndentFirstHashElement` cop has been renamed to `Layout/FirstHashElementIndentation`.
(obsolete configuration found in /Users/leontev/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/bundler/gems/rubocop_config-141e1b8251f5/default.yml, please update it)
```
Фиксим