### PR TITLE
update rubocop to 0.82

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.2
-before_install: gem install bundler -v 1.15.4
+  - 2.5.3
+before_install: gem install bundler -v 2.1.4
 script:
   - make lint
   - make test

--- a/appbooster_rubocop_config.gemspec
+++ b/appbooster_rubocop_config.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "bump", ">= 0.5.4"
 
-  spec.add_dependency "rubocop", "~> 0.75"
+  spec.add_dependency "rubocop", "~> 0.82"
   spec.add_dependency "rubocop-rspec", "~> 1.36"
 end

--- a/default.yml
+++ b/default.yml
@@ -20,11 +20,11 @@ AllCops:
 Layout/SpaceInLambdaLiteral:
   EnforcedStyle: require_space
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # Commonly used screens these days easily fit more than 80 characters.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
 
 Metrics/AbcSize:
@@ -71,4 +71,25 @@ Style/WordArray:
 
 Lint/UnlessMultipleConditions:
   Description: 'Do not use `unless` with multiple conditions.'
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
   Enabled: true

--- a/lib/rubocop/appbooster_rubocop_config/version.rb
+++ b/lib/rubocop/appbooster_rubocop_config/version.rb
@@ -1,3 +1,3 @@
 module AppboosterRubocopConfig
-  VERSION = "0.5".freeze
+  VERSION = "0.6".freeze
 end


### PR DESCRIPTION
#### :tophat: Что? Зачем?
Обновляем rubocop до 0.82

Ахтунг!!!! 
`Style/HashTransforKeys` доступно с ruby 2.5, а  `Style/HashTransformValues` - 2.4